### PR TITLE
Use `getPrivateKey()` instead of `env.PRIVATE_KEY`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'node'],
+  preset: 'ts-jest/presets/js-with-ts',
   testEnvironment: 'node',
+  transformIgnorePatterns: ["node_modules/(?!@probot/get-private-key)"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/auth-app": "^5.0.6",
-        "@octokit/rest": "^19.0.13"
+        "@octokit/rest": "^19.0.13",
+        "@probot/get-private-key": "^2.0.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.119",
@@ -1527,6 +1528,14 @@
       "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
+      }
+    },
+    "node_modules/@probot/get-private-key": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@probot/get-private-key/-/get-private-key-2.0.0.tgz",
+      "integrity": "sha512-JtEtf9Pr7PvggtyxWvjgz3TLMRL+xI5GLHNysN3FA91+iMIJ7h2Xwf87aVGuaYhzGUqLljo9snEToPniIFnWVA==",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5488,6 +5497,11 @@
       "requires": {
         "@octokit/openapi-types": "^18.0.0"
       }
+    },
+    "@probot/get-private-key": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@probot/get-private-key/-/get-private-key-2.0.0.tgz",
+      "integrity": "sha512-JtEtf9Pr7PvggtyxWvjgz3TLMRL+xI5GLHNysN3FA91+iMIJ7h2Xwf87aVGuaYhzGUqLljo9snEToPniIFnWVA=="
     },
     "@sinclair/typebox": {
       "version": "0.25.24",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@octokit/auth-app": "^5.0.6",
-    "@octokit/rest": "^19.0.13"
+    "@octokit/rest": "^19.0.13",
+    "@probot/get-private-key": "^2.0.0"
   }
 }

--- a/src/authorizer.ts
+++ b/src/authorizer.ts
@@ -53,7 +53,7 @@ const deleteInstallation = async (payload: any, getPrivateKeyOptions: GetPrivate
  * uninstalled from that organization.
  * @param event API Gateway Event containing GitHub webhook
  * @param allowedOrgs Array of authorized organizations
- * @param privateKeyOptions Options to pass to getPrivateKey()
+ * @param getPrivateKeyOptions Options to pass to getPrivateKey()
  * @returns Object containing authorization information
  */
 export const authorizer = async ({

--- a/src/authorizer.ts
+++ b/src/authorizer.ts
@@ -34,7 +34,7 @@ const deleteInstallation = async (payload: any, getPrivateKeyOptions: GetPrivate
     authStrategy: createAppAuth,
     auth: {
       appId: payload.installation.app_id,
-      privateKey: Buffer.from(privateKey, "base64").toString(),
+      privateKey,
       installationId,
     },
   });

--- a/src/authorizer.ts
+++ b/src/authorizer.ts
@@ -1,12 +1,15 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { createAppAuth } from "@octokit/auth-app";
 import { Octokit } from "@octokit/rest";
+import { getPrivateKey } from "@probot/get-private-key";
 
 type Response = {
   isAuthorized: boolean;
   httpCode: number;
   msg: string;
 };
+
+type GetPrivateKeyOptions = Parameters<typeof getPrivateKey>[0];
 
 const UNINSTALL_FAILED_RESPONSE: Response = {
   httpCode: 500,
@@ -18,9 +21,10 @@ const logger = (msg: string, obj: any = {}) => {
   console.log(JSON.stringify({ "@msg": msg, ...obj }));
 };
 
-const deleteInstallation = async (payload: any) => {
+const deleteInstallation = async (payload: any, getPrivateKeyOptions: GetPrivateKeyOptions) => {
   const installationId = payload.installation.id;
-  const privateKey = process.env.PRIVATE_KEY;
+  const privateKey = getPrivateKey(getPrivateKeyOptions);
+  console.log(privateKey);
 
   if (!privateKey) {
     logger("no private key");
@@ -49,14 +53,17 @@ const deleteInstallation = async (payload: any) => {
  * uninstalled from that organization.
  * @param event API Gateway Event containing GitHub webhook
  * @param allowedOrgs Array of authorized organizations
+ * @param privateKeyOptions Options to pass to getPrivateKey()
  * @returns Object containing authorization information
  */
 export const authorizer = async ({
   event,
   allowedOrgs,
+  getPrivateKeyOptions,
 }: {
   event: APIGatewayProxyEvent;
   allowedOrgs: string[];
+  getPrivateKeyOptions?: GetPrivateKeyOptions;
 }): Promise<Response> => {
   const payload = JSON.parse(event.body as string);
   const ghEvent = event.headers["X-GitHub-Event"] as string;
@@ -71,7 +78,7 @@ export const authorizer = async ({
     ) {
       logger("unauthorized installation created", lambdaEvent);
       try {
-        await deleteInstallation(payload);
+        await deleteInstallation(payload, getPrivateKeyOptions);
         return {
           msg: "Application was automatically uninstalled from an unauthorized account.",
           httpCode: 200,
@@ -108,7 +115,7 @@ export const authorizer = async ({
     logger("unauthorized webhook received", lambdaEvent);
 
     try {
-      await deleteInstallation(payload);
+      await deleteInstallation(payload, getPrivateKeyOptions);
       return {
         msg: "Organization is not authorized to use this application. Installation deleted.",
         httpCode: 200,

--- a/src/authorizer.ts
+++ b/src/authorizer.ts
@@ -24,7 +24,6 @@ const logger = (msg: string, obj: any = {}) => {
 const deleteInstallation = async (payload: any, getPrivateKeyOptions: GetPrivateKeyOptions) => {
   const installationId = payload.installation.id;
   const privateKey = getPrivateKey(getPrivateKeyOptions);
-  console.log(privateKey);
 
   if (!privateKey) {
     logger("no private key");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 


### PR DESCRIPTION
And add an optional parameter or settings to pass to `getPrivateKey()`. This allows programs to not set environment variables.