### PR TITLE
Pass in private key directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/auth-app": "^5.0.6",
-        "@octokit/rest": "^19.0.13",
-        "@probot/get-private-key": "^2.0.0"
+        "@octokit/rest": "^19.0.13"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.119",
@@ -1528,14 +1527,6 @@
       "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
-      }
-    },
-    "node_modules/@probot/get-private-key": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@probot/get-private-key/-/get-private-key-2.0.0.tgz",
-      "integrity": "sha512-JtEtf9Pr7PvggtyxWvjgz3TLMRL+xI5GLHNysN3FA91+iMIJ7h2Xwf87aVGuaYhzGUqLljo9snEToPniIFnWVA==",
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5497,11 +5488,6 @@
       "requires": {
         "@octokit/openapi-types": "^18.0.0"
       }
-    },
-    "@probot/get-private-key": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@probot/get-private-key/-/get-private-key-2.0.0.tgz",
-      "integrity": "sha512-JtEtf9Pr7PvggtyxWvjgz3TLMRL+xI5GLHNysN3FA91+iMIJ7h2Xwf87aVGuaYhzGUqLljo9snEToPniIFnWVA=="
     },
     "@sinclair/typebox": {
       "version": "0.25.24",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@octokit/auth-app": "^5.0.6",
-    "@octokit/rest": "^19.0.13",
-    "@probot/get-private-key": "^2.0.0"
+    "@octokit/rest": "^19.0.13"
   }
 }

--- a/tests/authorizer.test.ts
+++ b/tests/authorizer.test.ts
@@ -1,7 +1,6 @@
 import { authorizer } from "../src";
 import { makeInstallationEvent } from "./webhooks/installation";
 import { makeIssueCommentEvent } from "./webhooks/issue_comment";
-import { getPrivateKey } from "@probot/get-private-key";
 
 const mockDeleteInstallation = jest.fn().mockName("deleteInstallation");
 jest.mock("@octokit/rest", () => ({
@@ -14,15 +13,9 @@ jest.mock("@octokit/rest", () => ({
   })),
 }));
 
-jest.mock("@probot/get-private-key", () => ({
-  getPrivateKey: jest.fn().mockName("getPrivateKey").mockReturnValue("1234"),
-}));
-const mockGetPrivateKey = <jest.Mock>(<unknown>getPrivateKey);
-
 describe("default", () => {
   beforeEach(() => {
     mockDeleteInstallation.mockClear();
-    mockGetPrivateKey.mockClear();
     jest.resetModules();
   });
 
@@ -34,18 +27,13 @@ describe("default", () => {
         action: "created",
         orgName: "unauthorized_org",
       }),
-      getPrivateKeyOptions: {
-        env: {
-          PRIVATE_KEY: "abc",
-        },
-      },
+      privateKey: "1234",
     });
     expect(result).toStrictEqual({
       msg: "Application was automatically uninstalled from an unauthorized account.",
       httpCode: 200,
       isAuthorized: false,
     });
-    expect(mockGetPrivateKey).toHaveBeenCalledWith({ env: { PRIVATE_KEY: "abc" } });
   });
 
   test("unauthorized installation created | delete failed | octokit", async () => {
@@ -56,24 +44,8 @@ describe("default", () => {
         action: "created",
         orgName: "unauthorized_org",
       }),
+      privateKey: "1234",
     });
-    expect(result).toStrictEqual({
-      msg: "Unauthorized organization detected. Automatic uninstall failed.",
-      httpCode: 500,
-      isAuthorized: false,
-    });
-  });
-
-  test("unauthorized installation created | delete failed | missing PRIVATE_KEY", async () => {
-    mockGetPrivateKey.mockReturnValueOnce(null);
-    const result = await authorizer({
-      allowedOrgs: ["rapidsai"],
-      event: makeInstallationEvent({
-        action: "created",
-        orgName: "unauthorized_org",
-      }),
-    });
-    expect(mockDeleteInstallation).not.toHaveBeenCalled();
     expect(result).toStrictEqual({
       msg: "Unauthorized organization detected. Automatic uninstall failed.",
       httpCode: 500,
@@ -88,6 +60,7 @@ describe("default", () => {
         action: "created",
         orgName: "rapidsai",
       }),
+      privateKey: "1234",
     });
     expect(mockDeleteInstallation).not.toHaveBeenCalled();
     expect(result).toStrictEqual({
@@ -104,6 +77,7 @@ describe("default", () => {
         action: "created",
         orgName: "rapidsai",
       }),
+      privateKey: "1234",
     });
     expect(mockDeleteInstallation).not.toHaveBeenCalled();
     expect(result).toStrictEqual({
@@ -120,6 +94,7 @@ describe("default", () => {
         action: "created",
         orgName: "RAPIDSAI",
       }),
+      privateKey: "1234",
     });
     expect(mockDeleteInstallation).not.toHaveBeenCalled();
     expect(result).toStrictEqual({
@@ -136,6 +111,7 @@ describe("default", () => {
         action: "deleted",
         orgName: "unauthorized_org",
       }),
+      privateKey: "1234",
     });
     expect(mockDeleteInstallation).not.toHaveBeenCalled();
     expect(result).toStrictEqual({
@@ -152,6 +128,7 @@ describe("default", () => {
       event: makeIssueCommentEvent({
         orgName: "unauthorized_org",
       }),
+      privateKey: "1234",
     });
     expect(result).toStrictEqual({
       msg: "Organization is not authorized to use this application. Installation deleted.",
@@ -167,6 +144,7 @@ describe("default", () => {
       event: makeIssueCommentEvent({
         orgName: "unauthorized_org",
       }),
+      privateKey: "1234",
     });
     expect(result).toStrictEqual({
       msg: "Unauthorized organization detected. Automatic uninstall failed.",
@@ -182,6 +160,7 @@ describe("default", () => {
       event: makeIssueCommentEvent({
         orgName: "rapidsai",
       }),
+      privateKey: "1234",
     });
     expect(result).toStrictEqual({
       msg: "Organization is authorized.",
@@ -197,6 +176,7 @@ describe("default", () => {
       event: makeIssueCommentEvent({
         orgName: "RAPIDSAI",
       }),
+      privateKey: "1234",
     });
     expect(result).toStrictEqual({
       msg: "Organization is authorized.",
@@ -212,6 +192,7 @@ describe("default", () => {
       event: makeIssueCommentEvent({
         orgName: "rapidsai",
       }),
+      privateKey: "1234",
     });
     expect(result).toStrictEqual({
       msg: "Organization is authorized.",


### PR DESCRIPTION
Instead of calling `getPrivateKey()`, require the private key as an argument.